### PR TITLE
fix: build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/gecko-dev
 /obj-release
 /obj-debug
 /release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gecko-dev"]
+	path = gecko-dev
+	url = git@github.com:bytecodealliance/gecko-dev


### PR DESCRIPTION
This gets the build script to work for me for both the release and debug builds, by syncing it with the js-compute-runtime script.