### PR TITLE
Add builds for PBL+weval variant of SpiderMonkey.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,11 +31,22 @@ jobs:
       run: |
         mkdir dist
         sudo apt-get update -y
+
         bash ./build-engine.sh release
         tar -a -cf dist/spidermonkey-wasm-static-lib_release.tar.gz release
         rm -rf release obj-release
+
+        bash ./build-engine.sh release weval
+        tar -a -cf dist/spidermonkey-wasm-static-lib_release_weval.tar.gz release-weval
+        rm -rf release-weval obj-release-weval
+
         bash ./build-engine.sh debug
         tar -a -cf dist/spidermonkey-wasm-static-lib_debug.tar.gz debug
+        rm -rf debug obj-debug
+
+        bash ./build-engine.sh debug weval
+        tar -a -cf dist/spidermonkey-wasm-static-lib_debug_weval.tar.gz debug-weval
+        rm -rf debug-weval obj-debug-weval
 
     - name: Calculate tag name
       run: |

--- a/build-engine.sh
+++ b/build-engine.sh
@@ -7,9 +7,13 @@ working_dir="$(pwd)"
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 mode="${1:-release}"
-mozconfig="${working_dir}/mozconfig-${mode}"
-objdir="obj-$mode"
-outdir="$mode"
+weval=""
+if [[ $# > 1 ]] && [[ "$2" == "weval" ]]; then
+    weval=-weval
+fi
+mozconfig="${working_dir}/mozconfig-${mode}${weval}"
+objdir="obj-$mode${weval}"
+outdir="$mode${weval}"
 rebuild="${REBUILD_ENGINE:-0}"
 
 cat << EOF > "$mozconfig"
@@ -60,6 +64,15 @@ case "$mode" in
   *)
     echo "Unknown build type: $mode"
     exit 1
+    ;;
+esac
+
+case "$weval" in
+  -weval)
+    echo "ac_add_options --enable-portable-baseline-interp-force" >> "$mozconfig"
+    echo "ac_add_options --enable-aot-ics" >> "$mozconfig"
+    echo "ac_add_options --enable-aot-ics-force" >> "$mozconfig"
+    echo "ac_add_options --enable-pbl-weval" >> "$mozconfig"
     ;;
 esac
 

--- a/download-engine.sh
+++ b/download-engine.sh
@@ -12,9 +12,14 @@ if [[ $1 == "debug" ]]
 then
   mode="debug"
 fi
+weval=""
+if [[ $2 == "weval" ]]
+then
+    weval="_weval"
+fi
 
 git_rev="$(git -C "$script_dir" rev-parse HEAD)"
-file="spidermonkey-wasm-static-lib_${mode}.tar.gz"
+file="spidermonkey-wasm-static-lib_${mode}${weval}.tar.gz"
 bundle_url="${gh_url}/releases/download/rev_${git_rev}/${file}"
 
 curl --fail -L -O "$bundle_url"


### PR DESCRIPTION
This PR adds `release-weval` and `debug-weval` build artifacts, alongside existing `release` and `debug` artifacts.

It modifies the build script to add the appropriate configuration flags to the `mozconfig` if invoked as `build-engine.sh {release|debug} weval`, and adds the two new jobs to CI.

In addition, `download-engine.sh` is modified to support downloading these variants if invoked as `download-engine.sh {release|debug} weval`.

Names and paths of existing artifacts remain the same, so this is fully backward compatible. Further work in downstream consumers is needed to actually make use of the PBL+weval AOT compilation functionality.